### PR TITLE
Update NativeSettings.m

### DIFF
--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -12,10 +12,8 @@
 
 - (void)open:(CDVInvokedUrlCommand*)command
 {
-        if (&UIApplicationOpenSettingsURLString != NULL) {
-            NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
-            [[UIApplication sharedApplication] openURL:appSettings];
-        }
+        NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+        [[UIApplication sharedApplication] openURL:appSettings];
 }
 
 @end


### PR DESCRIPTION
Update to disabled the Xcode warning :
Comparison of adress of 'UIApplicationOpenSettingsURLString' not equal to a null pointer is always true.