### PR TITLE
Update for iOS 10

### DIFF
--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -11,9 +11,11 @@
 @implementation NativeSettings
 
 - (void)open:(CDVInvokedUrlCommand*)command
-{
-        NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
-        [[UIApplication sharedApplication] openURL:appSettings];
+{        
+        NSURL *url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+        if (url != nil) {
+            [[UIApplication sharedApplication] openURL:url options:[NSDictionary new] completionHandler:nil];
+        }
 }
 
 @end


### PR DESCRIPTION
Update the code for deprecated UIApplicationOpenSettingsURLString. This code open system settings on iOS 10.